### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It reads the Current Temperature, Set and Read the Operation mode (Auto, Manual,
 ### Installation
 * Copy file climate/atag-one.py to your ha_config_dir/custom_components/climate directory.
 * If your are using hasio on docker: Copy file climate/atag-one.py to /usr/share/hassio/homeassistant/custom_components/climate
+* If you are using hass.io installation on Raspberry PI:  Copy file climate/atag-one.py to config/custom_components. NB: If folder custom_components does not yet exist, create it first inside the config folder. 
 * Configure with config below.
 * Restart Home-Assistant.
 


### PR DESCRIPTION
Please add to installation instructions:
* If you are using hass.io installation on Raspberry PI:  Copy file climate/atag-one.py to config/custom_components. NB: If folder custom_components does not yet exist, create it first inside the config folder.